### PR TITLE
miscale: opt-in override for broken scale clock

### DIFF
--- a/import_data.sh
+++ b/import_data.sh
@@ -168,6 +168,30 @@ while [[ $loop_count -eq 0 ]] || [[ $i -lt $loop_count ]] ; do
 				miscale_offset_unixtime=$(( $miscale_unixtime + $miscale_time_zone * 3600 + $miscale_time_offset ))
 				miscale_time_shift=$(( $miscale_os_unixtime - $miscale_offset_unixtime ))
 				miscale_absolute_shift=${miscale_time_shift#-}
+
+				# Broken scale clock override (opt-in via miscale_time_force_on_broken): the Mi Body
+				# Composition Scale 2 keeps its clock only while powered; a battery swap or a low-power
+				# reset wipes it and the scale starts advertising measurements with an absurd timestamp
+				# (typically early 1970). Without this override, every reading is rejected by the
+				# miscale_time_unsync check until the user re-syncs the scale from the Mi Fit / Zepp
+				# Life app. When enabled, and only for clearly absurd timestamps (drift > 1 year or
+				# scale timestamp before 2020), replace the measurement time with the system time and
+				# deduplicate across the ~15-minute rebroadcast window via a sentinel in $switch_temp_path.
+				miscale_skip_block=false
+				if [[ $miscale_time_force_on_broken == "on" ]] && { (( $miscale_absolute_shift > 31536000 )) || (( $miscale_unixtime < 1577836800 )); } ; then
+					miscale_broken_sentinel="$switch_temp_path/miscale_broken_last_raw"
+					if [[ -f $miscale_broken_sentinel && "$(cat $miscale_broken_sentinel)" == "$miscale_unixtime" ]] ; then
+						echo "$(timenow) MISCALE|S400 * Broken clock reading $miscale_unixtime already imported in current rebroadcast window, skipping"
+						miscale_skip_block=true
+					else
+						echo "$(timenow) MISCALE|S400 * Broken scale clock detected ($miscale_time_shift s shift), overriding measurement timestamp with system time (miscale_time_force_on_broken=on)"
+						echo "$miscale_unixtime" > $miscale_broken_sentinel
+						miscale_offset_unixtime=$miscale_os_unixtime
+						miscale_absolute_shift=0
+					fi
+				fi
+
+				if [[ $miscale_skip_block == "false" ]] ; then
 				if (( $miscale_absolute_shift < $miscale_time_unsync )) ; then
 					miscale_found_entry=false
 
@@ -192,6 +216,7 @@ while [[ $loop_count -eq 0 ]] || [[ $i -lt $loop_count ]] ; do
 					fi
 				else echo "$(timenow) MISCALE|S400 * $miscale_time_shift s time difference, synchronize date and time scale"
 					echo "$(timenow) MISCALE|S400 * Time offset is set to $miscale_offset s"
+				fi
 				fi
 			fi
 		fi

--- a/user/export2garmin.cfg
+++ b/user/export2garmin.cfg
@@ -61,6 +61,13 @@ miscale_time_unsync=1200
 # Protection against duplicates. Difference between weighting in seconds, default is 30
 miscale_time_check=30
 
+# Force override of the scale timestamp with the system time when the scale clock is clearly broken
+# (drift greater than 1 year, or scale reports a date before 2020). Useful because the Mi Body
+# Composition Scale 2 has no backup battery for its clock: a battery swap or a low-power reset
+# makes it advertise measurements with an absurd timestamp (typically early 1970) until the user
+# re-syncs it from the Mi Fit / Zepp Life app. Allowed switch parameter is "off" or "on"
+miscale_time_force_on_broken=off
+
 # Parameters for MQTT broker, skip if you are not using. Allowed switch parameter is "off" or "on"
 switch_mqtt=off
 miscale_mqtt_passwd=password


### PR DESCRIPTION
## Problem

The Mi Body Composition Scale 2 has no backup battery for its internal clock. Whenever the scale loses power — for instance after replacing the AAA cells, or after a low-battery auto-reset — the clock is wiped and the scale begins advertising measurements with an absurd timestamp, typically somewhere in early 1970.

In the current `import_data.sh`, this state is undetectable from the user's point of view. The raw reading is picked up by `miscale_ble.py`, parsed correctly (weight and impedance come through fine), and then the time-sync guard in `import_data.sh` computes a drift of many years. That falls outside the `miscale_time_unsync` window (default 1200 s, effectively 20 minutes), so the reading is discarded:

```
MISCALE|S400 * 1772644016 s time difference, synchronize date and time scale
MISCALE|S400 * Time offset is set to  s
```

Nothing is written to `miscale_backup.csv`, nothing is uploaded to Garmin, and the user typically only notices weeks later that their weight chart has gone flat. The fix on the user side is to open Mi Fit / Zepp Life next to the scale and let the app push a new time, but most users don't know that's what the scale needs, and the log message — while technically correct — doesn't explain it.

## What this PR changes

A new opt-in switch is added to `user/export2garmin.cfg`:

```
# Force override of the scale timestamp with the system time when the scale clock is clearly broken
# (drift greater than 1 year, or scale reports a date before 2020). [...]
miscale_time_force_on_broken=off
```

Default is `off`, so the behaviour for every existing installation is byte-identical to before this PR. Users who have hit the broken-clock failure mode (or who just want resilience against the next battery swap) can flip it to `on` and the server will auto-recover by stamping the measurement with its own system time.

The override is deliberately narrow. It only triggers when the drift is unambiguously a broken clock:

- absolute drift greater than 1 year (31 536 000 s), **or**
- scale timestamp earlier than 2020-01-01 (1 577 836 800)

The existing intermediate-drift rejection (`miscale_time_unsync` .. 1 year) is left untouched, so genuine "please resync your scale" warnings still fire for minor clock drift. Only the pathological case is affected.

### Why this is safe

- **Opt-in, default off.** If you do not set `miscale_time_force_on_broken=on`, nothing changes.
- **Narrow trigger.** A 1-year threshold means the override cannot mask normal drift, DST confusion, or the user accidentally setting the wrong year on the phone. Only a clock that is clearly reset to near-epoch gets through.
- **No duplicates across the ~15-minute rebroadcast window.** After a weigh-in, the Mi Scale 2 keeps advertising the same record for about 15 minutes, which the cron hits every minute. Without care, the override would save 15 copies of the same weigh-in with 15 different system-time stamps. To prevent that, the raw (broken) scale timestamp of the last override is written to a sentinel file in `$switch_temp_path`. On every subsequent scan in that window the raw timestamp is unchanged, the sentinel matches, and the reading is skipped.
- **Normal dedup still works.** The next real weigh-in (after the user opens Mi Fit / Zepp Life and resyncs the scale, or after the next broken session with a different raw timestamp) has a different raw value, the sentinel no longer matches, and the measurement is saved normally.
- **Sentinel is ephemeral.** It lives in `$switch_temp_path` (typically `/dev/shm`, tmpfs), which is cleared on reboot. In the worst case — reboot mid-broadcast with the override enabled and a still-broken scale — you get one extra duplicate row. In practice you also keep getting them until you fix the scale's clock, which is the whole point of the override.

### What the log looks like

When the override fires:

```
MISCALE|S400 * Broken scale clock detected (1776959711 s shift), overriding measurement timestamp with system time (miscale_time_force_on_broken=on)
MISCALE|S400 * Saving import 1776967011 to miscale_backup.csv file
```

On subsequent scans in the same rebroadcast window:

```
MISCALE|S400 * Broken clock reading 4314444 already imported in current rebroadcast window, skipping
```

These two messages are the signal to the user that their scale's clock needs attention (battery or a Mi Fit / Zepp Life resync) while data keeps flowing to Garmin.

## Testing

An isolated harness drives the patched block against six scenarios. All pass:

| # | `miscale_time_force_on_broken` | drift           | expected                         | got |
|---|--------------------------------|-----------------|----------------------------------|-----|
| 1 | off                            | ~56 years (1970)| reject, as today                 | ✓   |
| 2 | on                             | ~56 years       | override, save 1 row, write sentinel | ✓ |
| 3 | on                             | same raw, rerun | skip, still 1 row                | ✓   |
| 4 | on                             | ~0 s            | normal path, no override         | ✓   |
| 5 | off                            | 30 min          | reject, as today                 | ✓   |
| 6 | on                             | 30 min          | still reject, override does not fire | ✓ |

The patched script was also deployed on a real Raspberry Pi running v3.6 against an actual Mi Scale 2 (post-resync, so no broken-clock path exercised on real hardware in the commit smoke test — the unit harness covers that branch). Normal capture, dedup and Garmin upload keep working unchanged.

## Backward compatibility

None of the existing variables change meaning. The new `miscale_time_force_on_broken` is introduced with `off` default, so tagged releases built from this PR behave exactly like master for users who do not touch their `export2garmin.cfg`.

## Disclosure

This patch was drafted with the assistance of an LLM (Claude, Anthropic) pair-programming with the contributor. All code was reviewed, tested, and is the contributor's responsibility. If you have a policy on AI-assisted contributions, happy to adjust.
